### PR TITLE
BREAKING CHANGE: rename path attribute to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ const normalized = rpj.normalize(packageJsonObject)
 Errors raised from parsing will use
 [`json-parse-even-better-errors`](http://npm.im/json-parse-even-better-errors),
 so they'll be of type `JSONParseError` and have a `code: 'EJSONPARSE'`
-property.  Errors will also always have a `path` member referring to the
-path originally passed into the function.
+property.  Errors will also always have a `file` member referring to the
+file originally passed into the function.
 
 ## Indentation
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const { resolve, dirname, join, relative } = require('path')
 const rpj = path => readFile(path, 'utf8')
   .then(data => readBinDir(path, normalize(stripUnderscores(parse(data)))))
   .catch(er => {
-    er.path = path
+    er.file = path
     throw er
   })
 


### PR DESCRIPTION
fix(parseError): use file not path attribute

In order to align with the way our other "fast" json parsers work the
`err.path` attribute needs to be renamed to `err.file`.

See
https://github.com/npm/read-package-json/blob/0ed746091ae80c058699e7ebda74a2015b328fc3/read-json.js#L472